### PR TITLE
Add basic site pages and product data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.next
+out
+dist
+.env
+

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,13 +1,16 @@
 // app/contact/page.tsx
 export default function ContactPage() {
   return (
-    <main style={{ padding: '2rem' }}>
-      <h1>Contact</h1>
-      <p style={{ marginTop: 12 }}>
-        Email: <a href="mailto:support@westcoastcollectibless.com">support@westcoastcollectibless.com</a>
+    <main className="p-8">
+      <h1 className="text-2xl font-semibold">Contact</h1>
+      <p className="mt-3">
+        Email:{' '}
+        <a className="underline" href="mailto:support@westcoastcollectibless.com">
+          support@westcoastcollectibless.com
+        </a>
       </p>
-      <p style={{ marginTop: 6 }}>Location: Santa Monica, California</p>
-      <p style={{ marginTop: 6 }}>Hours: Mon–Fri, 9am–5pm PT</p>
+      <p className="mt-3">Location: Santa Monica, California</p>
+      <p className="mt-3">Hours: Mon–Fri, 9am–5pm PT</p>
     </main>
-  );
+  )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 // app/page.tsx
-import { SITE, PRODUCTS } from '../lib/products'
+import { SITE, PRODUCTS } from '@/lib/products'
 
 export default function HomePage() {
   return (

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,15 +1,19 @@
 // app/privacy/page.tsx
 export default function PrivacyPage() {
   return (
-    <main style={{ padding: '2rem' }}>
-      <h1>Privacy Policy</h1>
-      <p style={{ marginTop: 12 }}>
+    <main className="p-8">
+      <h1 className="text-2xl font-semibold">Privacy Policy</h1>
+      <p className="mt-3">
         We collect only the information needed to process your order (name, email, shipping address).
         Payments are processed by Stripe; we do not store card numbers.
       </p>
-      <p style={{ marginTop: 12 }}>
-        For privacy requests, email <a href="mailto:support@westcoastcollectibless.com">support@westcoastcollectibless.com</a>.
+      <p className="mt-3">
+        For privacy requests, email{' '}
+        <a className="underline" href="mailto:support@westcoastcollectibless.com">
+          support@westcoastcollectibless.com
+        </a>
+        .
       </p>
     </main>
-  );
+  )
 }

--- a/app/returns/page.tsx
+++ b/app/returns/page.tsx
@@ -1,17 +1,20 @@
 // app/returns/page.tsx
 export default function ReturnsPage() {
   return (
-    <main style={{ padding: '2rem' }}>
-      <h1>Shipping & Returns</h1>
-      <p style={{ marginTop: 12 }}>
+    <main className="p-8">
+      <h1 className="text-2xl font-semibold">Shipping & Returns</h1>
+      <p className="mt-3">
         Orders ship within 2–3 business days via USPS with tracking from Santa Monica, California.
       </p>
-      <p style={{ marginTop: 12 }}>
+      <p className="mt-3">
         Returns accepted within 30 days of delivery on unused items. Buyer pays return shipping unless the item is defective.
       </p>
-      <p style={{ marginTop: 12 }}>
-        Questions? <a href="mailto:support@westcoastcollectibless.com">support@westcoastcollectibless.com</a>
+      <p className="mt-3">
+        Questions?{' '}
+        <a className="underline" href="mailto:support@westcoastcollectibless.com">
+          support@westcoastcollectibless.com
+        </a>
       </p>
     </main>
-  );
+  )
 }

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -1,2 +1,29 @@
-import type { Product } from './types'
-export const PRODUCTS: Product[] = [{ id: 'sample', name: 'Sample Item', price: 25, description: 'Placeholder product.', images: [] }]
+export type Product = {
+  id: string
+  name: string
+  category?: string
+  description: string
+  price: number
+  images: string[]
+  variations?: { paymentLink?: string }[]
+}
+
+export const SITE = {
+  brand: 'West Coast Collectibless',
+  policies: {
+    shipping: 'Orders ship within 2–3 business days via USPS from Santa Monica, CA.',
+    returns: 'Returns accepted within 30 days on unused items. Buyer pays return shipping unless defective.',
+  },
+}
+
+export const PRODUCTS: Product[] = [
+  {
+    id: 'sample',
+    name: 'Sample Item',
+    category: 'Collectible',
+    description: 'Placeholder product.',
+    price: 25,
+    images: [],
+    variations: [],
+  },
+]

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,22 +16,29 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/components/*": [
+        "./components/*"
+      ],
+      "@/lib/*": [
+        "./lib/*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
   "include": [
     "next-env.d.ts",
     "**/*.ts",
-    "**/*.tsx"
+    "**/*.tsx",
+    ".next/types/**/*.ts"
   ],
   "exclude": [
     "node_modules"
   ]
-}{
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@/components/*": ["./components/*"],
-      "@/lib/*": ["./lib/*"]
-    }
-  }
 }


### PR DESCRIPTION
## Summary
- add homepage product import and alias
- create simple product data with site policies
- build privacy, returns, and contact pages

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_6895ac3ae198832da8a6964140c3c303