### PR TITLE
fix: isolate interactive details link in client component

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@ export const runtime = 'nodejs'
 // app/page.tsx
 import { SITE } from '../lib/products'
 import { getListingsFromCsv } from '../lib/listings'
+import { DetailsButton } from '@/components/details-button'
 
 export default function HomePage() {
   return (
@@ -100,13 +101,7 @@ async function FeaturedFromCSV() {
                   >
                     {isStripe ? 'Buy Now' : 'View on eBay'}
                   </a>
-                  <a
-                    href="#"
-                    className="btn btn-secondary"
-                    onClick={(e) => { e.preventDefault(); alert('Details coming soon ✨'); }}
-                  >
-                    Details
-                  </a>
+                  <DetailsButton />
                 </div>
               </div>
             </article>

--- a/components/details-button.tsx
+++ b/components/details-button.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+export function DetailsButton() {
+  return (
+    <a
+      href="#"
+      className="btn btn-secondary"
+      onClick={(e) => {
+        e.preventDefault()
+        alert('Details coming soon ✨')
+      }}
+    >
+      Details
+    </a>
+  )
+}
+


### PR DESCRIPTION
## Summary
- move product details link into a small client component to handle clicks without server-side event handlers
- import the new client component in the featured listings page

## Testing
- `npm run dev`
- `curl -I http://localhost:3000`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896ee23379c832db0102bdd97658914